### PR TITLE
A-05/로그인 후 액세스 토큰도 쿠키에 담아서 응답

### DIFF
--- a/backend/src/main/java/com/example/backend/global/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/example/backend/global/auth/jwt/JwtProvider.java
@@ -10,7 +10,6 @@ import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
 import com.example.backend.domain.member.entity.Role;
 
 @Component
@@ -18,7 +17,7 @@ public class JwtProvider {
 
     private final Key SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
     private static final long ACCESS_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000; // 30분
-    public static final long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000;  // 7일
+    private static final long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000;  // 7일
     private final Logger logger = LoggerFactory.getLogger(JwtProvider.class);
 
     public String generateAccessToken(Long id, String username, Role role) {


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 로그인 기능 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### AS-IS (변경 전)
- accessToken은 헤더에, refreshToken은 쿠키에 담아서 보냄.
- 프론트는 accessToken을 로컬 스토리지에 저장하고 사용

### TO-BE (변경 후)
- accessToken도 쿠키에 담아서 응답하도록 수정
- 변경 이유는 accessToken을 갱신할 때 응답 값을 따로 넘겨 줄 필요가 없고, 프론트에서 따로 관리하지 않아도 되기 때문에 이렇게 적용함.
- 쿠키에 액세스 토큰을 같이 관리하는게 보안상 더 좋다는 이야기를 들어서 추후에 한번 정리할 예정

close #24 
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
