### PR TITLE
Feature/M-02 회원 조회 기능

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
@@ -2,14 +2,18 @@ package com.example.backend.domain.member.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.backend.domain.member.dto.MemberInfoResponse;
 import com.example.backend.domain.member.dto.MemberSignupForm;
 import com.example.backend.domain.member.service.MemberService;
+import com.example.backend.global.auth.model.CustomUserDetails;
 import com.example.backend.global.response.GenericResponse;
 import com.example.backend.global.validation.ValidationSequence;
 
@@ -31,4 +35,12 @@ public class MemberController {
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(GenericResponse.of());
 	}
+
+	@GetMapping
+	public ResponseEntity<GenericResponse<MemberInfoResponse>> getMemberInfo(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(GenericResponse.of(MemberInfoResponse.of(customUserDetails.getMember())));
+	}
+
 }

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoResponse.java
@@ -2,18 +2,16 @@ package com.example.backend.domain.member.dto;
 
 import com.example.backend.domain.common.Address;
 import com.example.backend.domain.member.entity.Member;
-import com.example.backend.domain.member.entity.MemberStatus;
 
 import lombok.Builder;
 
 @Builder
-public record MemberInfoResponse (String username, String nickname, MemberStatus memberStatus, Address address){
+public record MemberInfoResponse (String username, String nickname, Address address){
 
 	public static MemberInfoResponse of(Member member){
 		return MemberInfoResponse.builder()
 			.username(member.getUsername())
 			.nickname(member.getNickname())
-			.memberStatus(member.getMemberStatus())
 			.address(member.getAddress())
 			.build();
 	}

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoResponse.java
@@ -1,0 +1,20 @@
+package com.example.backend.domain.member.dto;
+
+import com.example.backend.domain.common.Address;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.member.entity.MemberStatus;
+
+import lombok.Builder;
+
+@Builder
+public record MemberInfoResponse (String username, String nickname, MemberStatus memberStatus, Address address){
+
+	public static MemberInfoResponse of(Member member){
+		return MemberInfoResponse.builder()
+			.username(member.getUsername())
+			.nickname(member.getNickname())
+			.memberStatus(member.getMemberStatus())
+			.address(member.getAddress())
+			.build();
+	}
+}

--- a/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
@@ -27,8 +27,6 @@ import com.example.backend.domain.member.exception.MemberErrorCode;
 import com.example.backend.domain.member.exception.MemberException;
 import com.example.backend.domain.member.service.MemberService;
 import com.example.backend.global.auth.model.CustomUserDetails;
-import com.example.backend.global.config.CorsConfig;
-import com.example.backend.global.config.TestSecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
@@ -432,7 +430,6 @@ class MemberControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.username").value("test@naver.com"))
 			.andExpect(jsonPath("$.data.nickname").value("testNickname"))
-			.andExpect(jsonPath("$.data.memberStatus").value("ACTIVE"))
 			.andExpect(jsonPath("$.data.address.city").value("testCity"))
 			.andExpect(jsonPath("$.data.address.district").value("testDistrict"))
 			.andExpect(jsonPath("$.data.address.country").value("testCountry"))


### PR DESCRIPTION
## 📌 회원 조회 기능

## 👩‍💻 요구 사항과 구현 내용

### 요구사항
- 멤버 정보를 조회하고 필요한 값만 응답해줌.
- `username`, `nickname`, `address` 만 리턴

### 구현 내용
- 컨트롤러에서 바로 인증객체로 MemberInfoResponse 객체를 만들어서 리턴
- 필터에서 인증 객체를 만들 때, 멤버 조회를 하기 때문에 서비스 에서 따로 조회하지 않음
- 예외는 필터에서 다 처리되기 때문에 실패 케이스는 따로 작성하지 않았음.

## ✅ 피드백 반영사항 
- 응답 데이터에 `memberStatus` 삭제

close #45 