### PR TITLE
Feature/M-03 회원 정보 수정 기능

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.backend.domain.member.conveter.MemberConverter;
 import com.example.backend.domain.member.dto.MemberInfoResponse;
+import com.example.backend.domain.member.dto.MemberModifyForm;
 import com.example.backend.domain.member.dto.MemberSignupForm;
 import com.example.backend.domain.member.service.MemberService;
 import com.example.backend.global.auth.model.CustomUserDetails;
@@ -44,4 +46,11 @@ public class MemberController {
 			.body(GenericResponse.of(MemberConverter.from(customUserDetails.getMember())));
 	}
 
+	@PatchMapping
+	public ResponseEntity<GenericResponse<MemberInfoResponse>> modify(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@RequestBody @Validated(ValidationSequence.class) MemberModifyForm memberModifyForm) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(GenericResponse.of(memberService.modify(customUserDetails.getMember().toModel(), memberModifyForm)));
+	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.backend.domain.member.conveter.MemberConverter;
 import com.example.backend.domain.member.dto.MemberInfoResponse;
 import com.example.backend.domain.member.dto.MemberSignupForm;
 import com.example.backend.domain.member.service.MemberService;
@@ -40,7 +41,7 @@ public class MemberController {
 	public ResponseEntity<GenericResponse<MemberInfoResponse>> getMemberInfo(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(GenericResponse.of(MemberInfoResponse.of(customUserDetails.getMember())));
+			.body(GenericResponse.of(MemberConverter.from(customUserDetails.getMember())));
 	}
 
 }

--- a/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
+++ b/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
@@ -1,0 +1,15 @@
+package com.example.backend.domain.member.conveter;
+
+import com.example.backend.domain.member.dto.MemberInfoResponse;
+import com.example.backend.domain.member.entity.Member;
+
+public final class MemberConverter {
+
+	public static MemberInfoResponse from(Member member){
+		return MemberInfoResponse.builder()
+			.username(member.getUsername())
+			.nickname(member.getNickname())
+			.address(member.getAddress())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
+++ b/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
@@ -16,7 +16,7 @@ public final class MemberConverter {
 			.build();
 	}
 
-	public static MemberDto from(MemberDto memberDto, MemberModifyForm memberModifyForm){
+	public static MemberDto of(MemberDto memberDto, MemberModifyForm memberModifyForm){
 		return MemberDto.builder()
 			.id(memberDto.id())
 			.username(memberDto.username())
@@ -24,13 +24,13 @@ public final class MemberConverter {
 			.password(memberDto.password())
 			.memberStatus(memberDto.memberStatus())
 			.role(memberDto.role())
-			.address(from(memberModifyForm))
+			.address(toAddress(memberModifyForm))
 			.createdAt(memberDto.createdAt())
 			.modifiedAt(memberDto.modifiedAt())
 			.build();
 	}
 
-	private static Address from(MemberModifyForm memberModifyForm) {
+	private static Address toAddress(MemberModifyForm memberModifyForm) {
 		return Address.builder()
 			.city(memberModifyForm.city())
 			.district(memberModifyForm.district())

--- a/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
+++ b/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
@@ -16,7 +16,7 @@ public final class MemberConverter {
 			.build();
 	}
 
-	public static MemberDto updateFrom(MemberDto memberDto, MemberModifyForm memberModifyForm){
+	public static MemberDto from(MemberDto memberDto, MemberModifyForm memberModifyForm){
 		return MemberDto.builder()
 			.id(memberDto.id())
 			.username(memberDto.username())
@@ -24,13 +24,13 @@ public final class MemberConverter {
 			.password(memberDto.password())
 			.memberStatus(memberDto.memberStatus())
 			.role(memberDto.role())
-			.address(toAddress(memberModifyForm))
+			.address(from(memberModifyForm))
 			.createdAt(memberDto.createdAt())
 			.modifiedAt(memberDto.modifiedAt())
 			.build();
 	}
 
-	private static Address toAddress(MemberModifyForm memberModifyForm) {
+	private static Address from(MemberModifyForm memberModifyForm) {
 		return Address.builder()
 			.city(memberModifyForm.city())
 			.district(memberModifyForm.district())

--- a/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
+++ b/backend/src/main/java/com/example/backend/domain/member/conveter/MemberConverter.java
@@ -1,6 +1,9 @@
 package com.example.backend.domain.member.conveter;
 
+import com.example.backend.domain.common.Address;
+import com.example.backend.domain.member.dto.MemberDto;
 import com.example.backend.domain.member.dto.MemberInfoResponse;
+import com.example.backend.domain.member.dto.MemberModifyForm;
 import com.example.backend.domain.member.entity.Member;
 
 public final class MemberConverter {
@@ -10,6 +13,29 @@ public final class MemberConverter {
 			.username(member.getUsername())
 			.nickname(member.getNickname())
 			.address(member.getAddress())
+			.build();
+	}
+
+	public static MemberDto updateFrom(MemberDto memberDto, MemberModifyForm memberModifyForm){
+		return MemberDto.builder()
+			.id(memberDto.id())
+			.username(memberDto.username())
+			.nickname(memberModifyForm.nickname())
+			.password(memberDto.password())
+			.memberStatus(memberDto.memberStatus())
+			.role(memberDto.role())
+			.address(toAddress(memberModifyForm))
+			.createdAt(memberDto.createdAt())
+			.modifiedAt(memberDto.modifiedAt())
+			.build();
+	}
+
+	private static Address toAddress(MemberModifyForm memberModifyForm) {
+		return Address.builder()
+			.city(memberModifyForm.city())
+			.district(memberModifyForm.district())
+			.country(memberModifyForm.country())
+			.detail(memberModifyForm.detail())
 			.build();
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberInfoResponse.java
@@ -1,18 +1,9 @@
 package com.example.backend.domain.member.dto;
 
 import com.example.backend.domain.common.Address;
-import com.example.backend.domain.member.entity.Member;
 
 import lombok.Builder;
 
 @Builder
 public record MemberInfoResponse (String username, String nickname, Address address){
-
-	public static MemberInfoResponse of(Member member){
-		return MemberInfoResponse.builder()
-			.username(member.getUsername())
-			.nickname(member.getNickname())
-			.address(member.getAddress())
-			.build();
-	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/dto/MemberModifyForm.java
+++ b/backend/src/main/java/com/example/backend/domain/member/dto/MemberModifyForm.java
@@ -1,0 +1,26 @@
+package com.example.backend.domain.member.dto;
+
+import com.example.backend.global.validation.ValidationGroups;
+import com.example.backend.global.validation.annotation.ValidNickname;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record MemberModifyForm (
+	@ValidNickname(groups = ValidationGroups.PatternGroup.class)
+	String nickname,
+
+	@NotBlank(message = "도시는 필수 항목 입니다.", groups = ValidationGroups.NotBlankGroup.class)
+	String city,
+
+	@NotBlank(message = "지역 구는 필수 항목 입니다.", groups = ValidationGroups.NotBlankGroup.class)
+	String district,
+
+	@NotBlank(message = "도로명 주소는 필수 항목 입니다.", groups = ValidationGroups.NotBlankGroup.class)
+	String country,
+
+	@NotBlank(message = "상세 주소는 필수 항목 입니다.", groups = ValidationGroups.NotBlankGroup.class)
+	String detail){
+
+}

--- a/backend/src/main/java/com/example/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/member/repository/MemberRepository.java
@@ -32,5 +32,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	 * @param username
 	 * @return {@link Optional<Member>}
 	 */
-  Optional<Member> findByUsername(String username);
+	Optional<Member> findByUsername(String username);
 }

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
@@ -109,7 +109,7 @@ public class MemberService {
 		existsNickname(memberModifyForm.nickname());
 
 		return MemberConverter.from(
-			memberRepository.save(Member.from(MemberConverter.updateFrom(memberDto, memberModifyForm))));
+			memberRepository.save(Member.from(MemberConverter.from(memberDto, memberModifyForm))));
 	}
 
 	private void existsNickname (String nickname) {

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
@@ -12,7 +12,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.backend.domain.common.Address;
 import com.example.backend.domain.common.EmailCertification;
 import com.example.backend.domain.common.VerifyType;
+import com.example.backend.domain.member.conveter.MemberConverter;
 import com.example.backend.domain.member.dto.MemberDto;
+import com.example.backend.domain.member.dto.MemberInfoResponse;
+import com.example.backend.domain.member.dto.MemberModifyForm;
 import com.example.backend.domain.member.entity.Member;
 import com.example.backend.domain.member.entity.MemberStatus;
 import com.example.backend.domain.member.entity.Role;
@@ -100,5 +103,20 @@ public class MemberService {
 	private String generateCertificationUrl(String to, String certificationCode, VerifyType verifyType) {
 		return verifyUrl + "email=" + to + "&certificationCode="
 			+ certificationCode + "&verifyType=" + verifyType.toString();
+	}
+
+	public MemberInfoResponse modify(MemberDto memberDto, MemberModifyForm memberModifyForm) {
+		existsNickname(memberModifyForm.nickname());
+
+		return MemberConverter.from(
+			memberRepository.save(Member.from(MemberConverter.updateFrom(memberDto, memberModifyForm))));
+	}
+
+	private void existsNickname (String nickname) {
+		boolean nicknameExists = memberRepository.existsByNickname(nickname);
+
+		if (nicknameExists) {
+			throw new MemberException(MemberErrorCode.EXISTS_NICKNAME);
+		}
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
@@ -109,7 +109,7 @@ public class MemberService {
 		existsNickname(memberModifyForm.nickname());
 
 		return MemberConverter.from(
-			memberRepository.save(Member.from(MemberConverter.from(memberDto, memberModifyForm))));
+			memberRepository.save(Member.from(MemberConverter.of(memberDto, memberModifyForm))));
 	}
 
 	private void existsNickname (String nickname) {

--- a/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
@@ -473,7 +473,7 @@ class MemberControllerTest {
 			.detail("updatedDetail")
 			.build();
 
-		MemberDto memberDto = MemberConverter.from(member.toModel(), memberModifyForm);
+		MemberDto memberDto = MemberConverter.of(member.toModel(), memberModifyForm);
 		Member updatedMember = Member.from(memberDto);
 		MemberInfoResponse response = MemberConverter.from(updatedMember);
 		when(memberService.modify(any(MemberDto.class), any(MemberModifyForm.class))).thenReturn(response);

--- a/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
@@ -4,6 +4,10 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.example.backend.domain.member.conveter.MemberConverter;
+import com.example.backend.domain.member.dto.MemberDto;
+import com.example.backend.domain.member.dto.MemberInfoResponse;
+import com.example.backend.domain.member.dto.MemberModifyForm;
 import com.example.backend.global.config.TestSecurityConfig;
 import com.example.backend.global.config.CorsConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -399,7 +403,7 @@ class MemberControllerTest {
 	}
 
 	@Test
-	@DisplayName("멤버 정보 조회")
+	@DisplayName("회원 정보 조회")
 	void getMemberInfo() throws Exception {
 		// given
 		Address address = Address.builder()
@@ -437,4 +441,326 @@ class MemberControllerTest {
 			.andExpect(jsonPath("$.success").value(true));
 
 	}
+
+	@Test
+	@DisplayName("회원 정보 수정 성공")
+	void modify_success() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickname")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		MemberDto memberDto = MemberConverter.updateFrom(member.toModel(), memberModifyForm);
+		Member updatedMember = Member.from(memberDto);
+		MemberInfoResponse response = MemberConverter.from(updatedMember);
+		when(memberService.modify(any(MemberDto.class), any(MemberModifyForm.class))).thenReturn(response);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.username").value("test@naver.com"))
+			.andExpect(jsonPath("$.data.nickname").value("updatedNickname"))
+			.andExpect(jsonPath("$.data.address.city").value("updatedCity"))
+			.andExpect(jsonPath("$.data.address.district").value("updatedDistrict"))
+			.andExpect(jsonPath("$.data.address.country").value("updatedCountry"))
+			.andExpect(jsonPath("$.data.address.detail").value("updatedDetail"))
+			.andExpect(jsonPath("$.success").value(true));
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 중복된 닉네임일 경우")
+	void modify_fail_nickname_already_exists() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("duplicateNickname")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		doThrow(new MemberException(MemberErrorCode.EXISTS_NICKNAME))
+			.when(memberService)
+			.modify(any(MemberDto.class), any(MemberModifyForm.class));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400-2"))
+			.andExpect(jsonPath("$.message").value("중복된 닉네임 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 닉네임 유효성 검사 실패")
+	void modify_fail_nickname_not_valid() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400-1"))
+			.andExpect(jsonPath("$.errorDetails[0].field").value("nickname"))
+			.andExpect(jsonPath("$.errorDetails[0].reason").value("유효하지 않은 회원 이름 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 도시 유효성 검사 실패")
+	void modify_fail_city_not_valid() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickname")
+			.city("")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400-1"))
+			.andExpect(jsonPath("$.errorDetails[0].field").value("city"))
+			.andExpect(jsonPath("$.errorDetails[0].reason").value("도시는 필수 항목 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 지역 구 유효성 검사 실패")
+	void modify_fail_district_not_valid() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickname")
+			.city("updatedCity")
+			.district("")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400-1"))
+			.andExpect(jsonPath("$.errorDetails[0].field").value("district"))
+			.andExpect(jsonPath("$.errorDetails[0].reason").value("지역 구는 필수 항목 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 도로명 주소 유효성 검사 실패")
+	void modify_fail_country_not_valid() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickname")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("")
+			.detail("updatedDetail")
+			.build();
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400-1"))
+			.andExpect(jsonPath("$.errorDetails[0].field").value("country"))
+			.andExpect(jsonPath("$.errorDetails[0].reason").value("도로명 주소는 필수 항목 입니다."));
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 상세 주소 유효성 검사 실패")
+	void modify_fail_detail_not_valid() throws Exception {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+		Member member = Member.builder()
+			.username("test@naver.com")
+			.nickname("testNickname")
+			.memberStatus(MemberStatus.ACTIVE)
+			.role(Role.ROLE_USER)
+			.address(address)
+			.build();
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+		// Authentication 설정
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickname")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("")
+			.build();
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/v1/members")
+			.with(SecurityMockMvcRequestPostProcessors.authentication(authenticationToken))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberModifyForm)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400-1"))
+			.andExpect(jsonPath("$.errorDetails[0].field").value("detail"))
+			.andExpect(jsonPath("$.errorDetails[0].reason").value("상세 주소는 필수 항목 입니다."));
+	}
+
 }

--- a/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/controller/MemberControllerTest.java
@@ -473,7 +473,7 @@ class MemberControllerTest {
 			.detail("updatedDetail")
 			.build();
 
-		MemberDto memberDto = MemberConverter.updateFrom(member.toModel(), memberModifyForm);
+		MemberDto memberDto = MemberConverter.from(member.toModel(), memberModifyForm);
 		Member updatedMember = Member.from(memberDto);
 		MemberInfoResponse response = MemberConverter.from(updatedMember);
 		when(memberService.modify(any(MemberDto.class), any(MemberModifyForm.class))).thenReturn(response);

--- a/backend/src/test/java/com/example/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/service/MemberServiceTest.java
@@ -204,7 +204,7 @@ class MemberServiceTest {
 			.detail("updatedDetail")
 			.build();
 
-		Member member = Member.from(MemberConverter.from(memberDto, memberModifyForm));
+		Member member = Member.from(MemberConverter.of(memberDto, memberModifyForm));
 		when(memberRepository.existsByNickname(memberModifyForm.nickname())).thenReturn(false);
 		when(memberRepository.save(any(Member.class))).thenReturn(member);
 

--- a/backend/src/test/java/com/example/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/service/MemberServiceTest.java
@@ -1,8 +1,8 @@
 package com.example.backend.domain.member.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +12,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.example.backend.domain.common.Address;
+import com.example.backend.domain.member.conveter.MemberConverter;
 import com.example.backend.domain.member.dto.MemberDto;
+import com.example.backend.domain.member.dto.MemberInfoResponse;
+import com.example.backend.domain.member.dto.MemberModifyForm;
 import com.example.backend.domain.member.dto.MemberSignupForm;
 import com.example.backend.domain.member.entity.Member;
 import com.example.backend.domain.member.entity.Role;
@@ -27,12 +30,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 class MemberServiceTest {
 	@Mock
 	private MemberRepository memberRepository;
+
 	@Mock
 	private RedisService redisService;
+
 	@Mock
 	private MailService mailService;
+
 	@Mock
 	private PasswordEncoder passwordEncoder;
+
 	@Mock
 	private ObjectMapper objectMapper;
 
@@ -123,7 +130,7 @@ class MemberServiceTest {
 		given(memberRepository.existsByNickname(givenMember.nickname())).willReturn(false);
 
 		//when & then
-		Assertions.assertThatThrownBy(() -> memberService.signup(
+		assertThatThrownBy(() -> memberService.signup(
 				givenMemberSignupForm.username(), givenMemberSignupForm.nickname(),
 				givenMemberSignupForm.password(), givenMemberSignupForm.city(), givenMemberSignupForm.district(),
 				givenMemberSignupForm.country(), givenMemberSignupForm.detail()))
@@ -165,10 +172,83 @@ class MemberServiceTest {
 		given(memberRepository.existsByNickname(givenMember.nickname())).willReturn(true);
 
 		//when & then
-		Assertions.assertThatThrownBy(() -> memberService.signup(
+		assertThatThrownBy(() -> memberService.signup(
 				givenMemberSignupForm.username(), givenMemberSignupForm.nickname(),
 				givenMemberSignupForm.password(), givenMemberSignupForm.city(), givenMemberSignupForm.district(),
 				givenMemberSignupForm.country(), givenMemberSignupForm.detail()))
+			.isInstanceOf(MemberException.class)
+			.hasMessage(MemberErrorCode.EXISTS_NICKNAME.getMessage());
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 성공 테스트")
+	void modify_success() {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+
+		MemberDto memberDto = MemberDto.builder()
+			.nickname("testNickName")
+			.address(address)
+			.build();
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickName")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		Member member = Member.from(MemberConverter.updateFrom(memberDto, memberModifyForm));
+		when(memberRepository.existsByNickname(memberModifyForm.nickname())).thenReturn(false);
+		when(memberRepository.save(any(Member.class))).thenReturn(member);
+
+		// when
+		MemberInfoResponse result = memberService.modify(memberDto, memberModifyForm);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).isInstanceOf(MemberInfoResponse.class);
+		assertThat(result.nickname()).isEqualTo(memberModifyForm.nickname());
+		assertThat(result.address().getCity()).isEqualTo(memberModifyForm.city());
+		assertThat(result.address().getDistrict()).isEqualTo(memberModifyForm.district());
+		assertThat(result.address().getCountry()).isEqualTo(memberModifyForm.country());
+		assertThat(result.address().getDetail()).isEqualTo(memberModifyForm.detail());
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 실패 - 닉네임 중복")
+	void modify_fail_nickname_already_exists() {
+		// given
+		Address address = Address.builder()
+			.city("testCity")
+			.district("testDistrict")
+			.country("testCountry")
+			.detail("testDetail")
+			.build();
+
+		MemberDto memberDto = MemberDto.builder()
+			.nickname("testNickName")
+			.address(address)
+			.build();
+
+		MemberModifyForm memberModifyForm = MemberModifyForm.builder()
+			.nickname("updatedNickName")
+			.city("updatedCity")
+			.district("updatedDistrict")
+			.country("updatedCountry")
+			.detail("updatedDetail")
+			.build();
+
+		when(memberRepository.existsByNickname(memberModifyForm.nickname())).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> memberService.modify(memberDto, memberModifyForm))
 			.isInstanceOf(MemberException.class)
 			.hasMessage(MemberErrorCode.EXISTS_NICKNAME.getMessage());
 	}

--- a/backend/src/test/java/com/example/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/service/MemberServiceTest.java
@@ -204,7 +204,7 @@ class MemberServiceTest {
 			.detail("updatedDetail")
 			.build();
 
-		Member member = Member.from(MemberConverter.updateFrom(memberDto, memberModifyForm));
+		Member member = Member.from(MemberConverter.from(memberDto, memberModifyForm));
 		when(memberRepository.existsByNickname(memberModifyForm.nickname())).thenReturn(false);
 		when(memberRepository.save(any(Member.class))).thenReturn(member);
 


### PR DESCRIPTION
## 📌 회원 정보 수정 기능

## 👩‍💻 요구 사항과 구현 내용 

### 요구사항
- 회원의 닉네임과 주소를 수정 할 수 있다.
- 닉네임이 중복일 경우 EXISTS_NICKNAME 에러 코드 리턴

### 구현 내용
- Member -> MemberInfoResponse, (MemberDto, MemberModifyForm) -> MemberDto 변환 메서드 컨버터에서 관리하도록 함.
- 요구사항에 대한 기능 구현

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
`MemberService` 에서 `existsNickname` 메서드 따로 만들었는데, `existsMember` 를 `existsNickname`, `existsUsername` 두개의 메서드로 나눠도 괜찮을까요? 동오님 코드는 최대한 안건드렸습니다.

close #47 