### PR TITLE
fix: 로그아웃 시 액세스 토큰도 쿠키에서 삭제 #57

### DIFF
--- a/backend/src/main/java/com/example/backend/global/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/backend/global/auth/controller/AuthController.java
@@ -45,6 +45,7 @@ public class AuthController {
         String accessToken = cookieService.getAccessTokenFromRequest(request);
 
         authService.logout(accessToken);
+		cookieService.deleteAccessTokenFromCookie(response);
         cookieService.deleteRefreshTokenFromCookie(response);
 
         return ResponseEntity.status(HttpStatus.OK).body(GenericResponse.of("로그아웃 성공"));


### PR DESCRIPTION
## 📌 로그아웃 시 액세스 토큰도 쿠키 삭제

## 👩‍💻 요구 사항과 구현 내용 
- 원래는 로그아웃 하면 리프레시 토큰만 삭제 했었는데, 액세스 토큰도 삭제하도록 수정