### PR TITLE
Feature/C-02 장바구니 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
@@ -42,6 +42,6 @@ public class CartController {
 
         List<CartResponse> cartResponses = cartService.getCartsByMember(memberId, member);
 
-        return ResponseEntity.ok(GenericResponse.of(cartResponses));
+        return ResponseEntity.status(HttpStatus.OK).body(GenericResponse.of(cartResponses));
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.example.backend.domain.cart.controller;
 
 import com.example.backend.domain.cart.dto.CartForm;
+import com.example.backend.domain.cart.dto.CartResponse;
 import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.entity.Member;
 import com.example.backend.global.auth.model.CustomUserDetails;
@@ -10,10 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +31,17 @@ public class CartController {
         Long cartId = cartService.addCartItem(cartForm, member);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(GenericResponse.of(cartId));
+    }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<GenericResponse<List<CartResponse>>> getCarts(
+            @PathVariable("id") Long memberId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
+
+        List<CartResponse> cartResponses = cartService.getCartsByMember(memberId, member);
+
+        return ResponseEntity.ok(GenericResponse.of(cartResponses));
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
@@ -33,14 +33,13 @@ public class CartController {
         return ResponseEntity.status(HttpStatus.CREATED).body(GenericResponse.of(cartId));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping
     public ResponseEntity<GenericResponse<List<CartResponse>>> getCarts(
-            @PathVariable("id") Long memberId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         Member member = customUserDetails.getMember();
 
-        List<CartResponse> cartResponses = cartService.getCartsByMember(memberId, member);
+        List<CartResponse> cartResponses = cartService.getCartsByMember(member);
 
         return ResponseEntity.status(HttpStatus.OK).body(GenericResponse.of(cartResponses));
     }

--- a/backend/src/main/java/com/example/backend/domain/cart/converter/CartConverter.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/converter/CartConverter.java
@@ -8,6 +8,8 @@ import com.example.backend.domain.product.entity.Product;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CartConverter {
 
@@ -42,5 +44,17 @@ public class CartConverter {
                 .totalPrice(cart.getProduct().getPrice() * cart.getQuantity())
                 .productImgUrl(cart.getProduct().getImgUrl())
                 .build();
+    }
+
+    /**
+     * Cart 엔티티 리스트 -> CartResponse 리스트 변환
+     *
+     * @param cartList Cart 엔티티 리스트
+     * @return 응답 DTO 리스트
+     */
+    public static List<CartResponse> toResponseList(List<Cart> cartList) {
+        return cartList.stream()
+                .map(CartConverter::toResponse)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/exception/CartErrorCode.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/exception/CartErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CartErrorCode {
     ALREADY_EXISTS_IN_CART(HttpStatus.BAD_REQUEST, "이미 장바구니에 추가된 상품입니다.", "400-1"),
-    INVALID_QUANTITY(HttpStatus.BAD_REQUEST,"상품을 최소 1개 이상 추가하여야 합니다." ,"400-2");
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST,"상품을 최소 1개 이상 추가하여야 합니다." ,"400-2"),
+    INVALID_MEMBER(HttpStatus.FORBIDDEN,"요청한 회원 ID와 로그인한 회원 ID가 다릅니다." ,"403-1");
 
     final HttpStatus httpStatus;
     final String message;

--- a/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
@@ -1,9 +1,17 @@
 package com.example.backend.domain.cart.repository;
 
 import com.example.backend.domain.cart.entity.Cart;
+import com.example.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     boolean existsByProductId_IdAndMemberId_Id(Long productId, Long memberId);
+
+    @Query("SELECT c FROM Cart c JOIN FETCH c.product WHERE c.member = :member")
+    List<Cart> findAllByMemberWithProducts(@Param("member") Member member);
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
@@ -11,9 +11,9 @@ import com.example.backend.domain.member.entity.Member;
 import com.example.backend.domain.product.service.ProductService;
 import com.example.backend.global.auth.exception.AuthErrorCode;
 import com.example.backend.global.auth.exception.AuthException;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -55,17 +55,7 @@ public class CartService {
     }
 
     @Transactional(readOnly = true)
-    public List<CartResponse> getCartsByMember(Long memberId, Member member) {
-        // 요청한 회원이 존재하지 않으면 exception 발생
-        if (member == null) {
-            throw new AuthException(AuthErrorCode.MEMBER_NOT_FOUND);
-        }
-
-        // 로그인한 회원과 요청한 회원이 다르면 exception 발생
-        if (!member.getId().equals(memberId)) {
-            throw new CartException(CartErrorCode.INVALID_MEMBER);
-        }
-
+    public List<CartResponse> getCartsByMember(Member member) {
         List<Cart> cartList = cartRepository.findAllByMemberWithProducts(member);
 
         return CartConverter.toResponseList(cartList);

--- a/backend/src/test/java/com/example/backend/domain/cart/controller/CartControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/cart/controller/CartControllerTest.java
@@ -1,6 +1,8 @@
 package com.example.backend.domain.cart.controller;
 
 import com.example.backend.domain.cart.dto.CartForm;
+import com.example.backend.domain.cart.dto.CartResponse;
+import com.example.backend.domain.cart.exception.CartErrorCode;
 import com.example.backend.domain.cart.exception.CartException;
 import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.entity.Member;
@@ -15,6 +17,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -45,6 +49,11 @@ class CartControllerTest {
         cartForm = new CartForm(1L, 1L, 2);
     }
 
+    /**
+     * addCartItem() 메서드 테스트
+     * - 장바구니에 상품 추가
+     * @throws CartException
+     */
     @Test
     @WithMockUser
     @DisplayName("장바구니에 상품 추가")
@@ -61,5 +70,74 @@ class CartControllerTest {
         assertEquals(cartId, response.getBody().getData());
 
         verify(cartService).addCartItem(cartForm, member);
+    }
+
+    /**
+     * getCarts() 메서드 테스트
+     * - 회원의 장바구니 목록 조회
+     * - 다른 회원의 장바구니 접근 시 예외 발생
+     * - 빈 장바구니 목록 조회
+     * @throws CartException
+     */
+    @Test
+    @WithMockUser
+    @DisplayName("회원의 장바구니 목록 조회 성공")
+    void getCarts_Success() {
+        // given
+        Long memberId = 1L;
+        CartResponse cartResponse = new CartResponse(1L,"testProductName", 10, 1000, 10000, "test.jpg");
+        List<CartResponse> cartResponses = List.of(cartResponse);
+
+        when(cartService.getCartsByMember(memberId, member)).thenReturn(cartResponses);
+
+        // when
+        ResponseEntity<GenericResponse<List<CartResponse>>> response =
+                cartController.getCarts(memberId, customUserDetails);
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().getData().size());
+        assertEquals(cartResponse.productName(), response.getBody().getData().get(0).productName());
+
+        verify(cartService).getCartsByMember(memberId, member);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("다른 회원의 장바구니 접근 시 예외 발생")
+    void getCarts_WithDifferentMember_ThrowsCartException() {
+        // given
+        Long differentMemberId = 2L;
+        when(cartService.getCartsByMember(differentMemberId, member))
+                .thenThrow(new CartException(CartErrorCode.INVALID_MEMBER));
+
+        // when & then
+        assertThrows(CartException.class, () ->
+                cartController.getCarts(differentMemberId, customUserDetails));
+
+        verify(cartService).getCartsByMember(differentMemberId, member);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("빈 장바구니 목록 조회")
+    void getCarts_WithEmptyCart_ReturnsEmptyList() {
+        // given
+        Long memberId = 1L;
+        List<CartResponse> emptyCartResponses = List.of();
+
+        when(cartService.getCartsByMember(memberId, member)).thenReturn(emptyCartResponses);
+
+        // when
+        ResponseEntity<GenericResponse<List<CartResponse>>> response =
+                cartController.getCarts(memberId, customUserDetails);
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getData().isEmpty());
+
+        verify(cartService).getCartsByMember(memberId, member);
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/cart/controller/CartControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/cart/controller/CartControllerTest.java
@@ -2,7 +2,6 @@ package com.example.backend.domain.cart.controller;
 
 import com.example.backend.domain.cart.dto.CartForm;
 import com.example.backend.domain.cart.dto.CartResponse;
-import com.example.backend.domain.cart.exception.CartErrorCode;
 import com.example.backend.domain.cart.exception.CartException;
 import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.entity.Member;
@@ -75,7 +74,6 @@ class CartControllerTest {
     /**
      * getCarts() 메서드 테스트
      * - 회원의 장바구니 목록 조회
-     * - 다른 회원의 장바구니 접근 시 예외 발생
      * - 빈 장바구니 목록 조회
      * @throws CartException
      */
@@ -88,11 +86,11 @@ class CartControllerTest {
         CartResponse cartResponse = new CartResponse(1L,"testProductName", 10, 1000, 10000, "test.jpg");
         List<CartResponse> cartResponses = List.of(cartResponse);
 
-        when(cartService.getCartsByMember(memberId, member)).thenReturn(cartResponses);
+        when(cartService.getCartsByMember(member)).thenReturn(cartResponses);
 
         // when
         ResponseEntity<GenericResponse<List<CartResponse>>> response =
-                cartController.getCarts(memberId, customUserDetails);
+                cartController.getCarts(customUserDetails);
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -100,23 +98,7 @@ class CartControllerTest {
         assertEquals(1, response.getBody().getData().size());
         assertEquals(cartResponse.productName(), response.getBody().getData().get(0).productName());
 
-        verify(cartService).getCartsByMember(memberId, member);
-    }
-
-    @Test
-    @WithMockUser
-    @DisplayName("다른 회원의 장바구니 접근 시 예외 발생")
-    void getCarts_WithDifferentMember_ThrowsCartException() {
-        // given
-        Long differentMemberId = 2L;
-        when(cartService.getCartsByMember(differentMemberId, member))
-                .thenThrow(new CartException(CartErrorCode.INVALID_MEMBER));
-
-        // when & then
-        assertThrows(CartException.class, () ->
-                cartController.getCarts(differentMemberId, customUserDetails));
-
-        verify(cartService).getCartsByMember(differentMemberId, member);
+        verify(cartService).getCartsByMember(member);
     }
 
     @Test
@@ -127,17 +109,17 @@ class CartControllerTest {
         Long memberId = 1L;
         List<CartResponse> emptyCartResponses = List.of();
 
-        when(cartService.getCartsByMember(memberId, member)).thenReturn(emptyCartResponses);
+        when(cartService.getCartsByMember(member)).thenReturn(emptyCartResponses);
 
         // when
         ResponseEntity<GenericResponse<List<CartResponse>>> response =
-                cartController.getCarts(memberId, customUserDetails);
+                cartController.getCarts(customUserDetails);
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         assertTrue(response.getBody().getData().isEmpty());
 
-        verify(cartService).getCartsByMember(memberId, member);
+        verify(cartService).getCartsByMember(member);
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/cart/service/CartServiceTest.java
+++ b/backend/src/test/java/com/example/backend/domain/cart/service/CartServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.backend.domain.cart.service;
 
 import com.example.backend.domain.cart.dto.CartForm;
+import com.example.backend.domain.cart.dto.CartResponse;
 import com.example.backend.domain.cart.entity.Cart;
 import com.example.backend.domain.cart.exception.CartException;
 import com.example.backend.domain.cart.repository.CartRepository;
@@ -18,9 +19,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -69,6 +72,13 @@ class CartServiceTest {
                 .build();
     }
 
+    /**
+     * addCartItem() 메서드 테스트
+     * - 장바구니에 상품 추가 성공
+     * - 회원 정보가 일치하지 않으면 예외 발생
+     * - 수량이 0 이하면 예외 발생
+     * - 이미 장바구니에 존재하는 상품이면 예외 발생
+     */
     @Test
     @DisplayName("장바구니에 상품 추가 성공")
     void addCartItem_Success() {
@@ -123,5 +133,52 @@ class CartServiceTest {
         assertThatThrownBy(() -> cartService.addCartItem(cartForm, member))
                 .isInstanceOf(CartException.class)
                 .hasMessage("이미 장바구니에 추가된 상품입니다.");
+    }
+
+    /**
+     * getCartsByMember() 메서드 테스트
+     * - 회원의 장바구니 목록 조회 성공
+     * - 회원이 null이면 예외 발생
+     * - 로그인한 회원과 요청한 회원이 다르면 예외 발생
+     */
+
+    @Test
+    @DisplayName("회원의 장바구니 목록 조회 성공")
+    void getCartsByMember_Success() {
+        // given
+        List<Cart> cartList = List.of(cart);
+        given(cartRepository.findAllByMemberWithProducts(member)).willReturn(cartList);
+
+        // when
+        List<CartResponse> result = cartService.getCartsByMember(member.getId(), member);
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result.size()).isEqualTo(1);
+        verify(cartRepository).findAllByMemberWithProducts(member);
+    }
+
+    @Test
+    @DisplayName("회원이 null이면 예외 발생")
+    void getCartsByMember_WithNullMember_ThrowsAuthException() {
+        // given
+        Member nullMember = null;
+
+        // when & then
+        assertThatThrownBy(() -> cartService.getCartsByMember(1L, nullMember))
+                .isInstanceOf(AuthException.class)
+                .hasMessage("해당 유저가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("로그인한 회원과 요청한 회원이 다르면 예외 발생")
+    void getCartsByMember_WithDifferentMember_ThrowsCartException() {
+        // given
+        Long differentMemberId = 2L;
+
+        // when & then
+        assertThatThrownBy(() -> cartService.getCartsByMember(differentMemberId, member))
+                .isInstanceOf(CartException.class)
+                .hasMessage("요청한 회원 ID와 로그인한 회원 ID가 다릅니다.");
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/cart/service/CartServiceTest.java
+++ b/backend/src/test/java/com/example/backend/domain/cart/service/CartServiceTest.java
@@ -138,8 +138,6 @@ class CartServiceTest {
     /**
      * getCartsByMember() 메서드 테스트
      * - 회원의 장바구니 목록 조회 성공
-     * - 회원이 null이면 예외 발생
-     * - 로그인한 회원과 요청한 회원이 다르면 예외 발생
      */
 
     @Test
@@ -150,7 +148,7 @@ class CartServiceTest {
         given(cartRepository.findAllByMemberWithProducts(member)).willReturn(cartList);
 
         // when
-        List<CartResponse> result = cartService.getCartsByMember(member.getId(), member);
+        List<CartResponse> result = cartService.getCartsByMember(member);
 
         // then
         assertThat(result).isNotEmpty();
@@ -158,27 +156,4 @@ class CartServiceTest {
         verify(cartRepository).findAllByMemberWithProducts(member);
     }
 
-    @Test
-    @DisplayName("회원이 null이면 예외 발생")
-    void getCartsByMember_WithNullMember_ThrowsAuthException() {
-        // given
-        Member nullMember = null;
-
-        // when & then
-        assertThatThrownBy(() -> cartService.getCartsByMember(1L, nullMember))
-                .isInstanceOf(AuthException.class)
-                .hasMessage("해당 유저가 존재하지 않습니다.");
-    }
-
-    @Test
-    @DisplayName("로그인한 회원과 요청한 회원이 다르면 예외 발생")
-    void getCartsByMember_WithDifferentMember_ThrowsCartException() {
-        // given
-        Long differentMemberId = 2L;
-
-        // when & then
-        assertThatThrownBy(() -> cartService.getCartsByMember(differentMemberId, member))
-                .isInstanceOf(CartException.class)
-                .hasMessage("요청한 회원 ID와 로그인한 회원 ID가 다릅니다.");
-    }
 }


### PR DESCRIPTION
## 📌 과제 설명
- 로그인한 회원이 본인의 장바구니를 조회합니다.

## 👩‍💻 요구 사항과 구현 내용
- GET | endpoint : /api/v1/carts
- 회원은 JWT 인증을 통해 본인의 장바구니를 조회합니다.
- 응답 데이터는 CartResponse 객체의 리스트로 반환됩니다.
- CartResponse
    - id
    - productName : 상품이름
    - quantity : 상품 수량
    - productPrice : 상품 가격
    - totalPrice : 모든 상품의 최종 합산 가격
    - productImgUrl : 상품 이미지 URL
- 조회 하는 메서드(getCarts) 추가
- 컨버터 클래스에 반환 받은 CartResponse를 리스트화 시키는 toRespnseList 메서드 추가
- JWT 인증을 통한 member의 장바구니를 조회하는 getCartsByMember 메서드 추가
- 이 로직을 테스트하는 메서드 추가

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
- 기본적으로 JWT 인증을 한 회원의 장바구니를 조회(GET)하는 것이기 때문에 불필요한 예외처리는 없애고, 단순히 로그인을 한 회원의 장바구니를 조회하는 로직으로 구성하였습니다.

Close #53
