### PR TITLE
Feature/P-05 상품 수정 시 해당 상품 id제외하고 상품 이름 중복 체크하는 로직 추가

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/product/repository/ProductRepository.java
@@ -31,4 +31,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     boolean existsByName(String name);
 
+    boolean existsByNameAndIdNot(String name, Long id);
+
 }

--- a/backend/src/main/java/com/example/backend/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/example/backend/domain/product/service/ProductService.java
@@ -53,9 +53,26 @@ public class ProductService {
         return productResponsePage;
     }
 
-    public void existsProduct(String name) {
+    /**
+     * 상품 등록 시 이름 중복 검증 메서드
+     * @param name
+     */
+    private void existsProduct(String name) {
 
         if(productRepository.existsByName(name)) {
+            throw new ProductException(ProductErrorCode.EXISTS_NAME);
+        }
+    }
+
+    /**
+     * 상품 수정 시 이름 중복 검증 메서드
+     * 수정시엔 해당 상품의 기존 이름은 중복 검증에서 제외
+     * @param id
+     * @param name
+     */
+    private void existsProduct(Long id, String name) {
+
+        if(productRepository.existsByNameAndIdNot(name, id)) {
             throw new ProductException(ProductErrorCode.EXISTS_NAME);
         }
     }
@@ -70,6 +87,7 @@ public class ProductService {
     @Transactional
     public void modify(Long id, ProductForm productForm) {
 
+        existsProduct(id, productForm.name());
         findById(id).modify(productForm);
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/product/controller/ProductControllerTest.java
@@ -419,4 +419,33 @@ public class ProductControllerTest {
                 .andExpect(jsonPath("$.message").value("상품을 찾을 수 없습니다."));
     }
 
+    @Test
+    @DisplayName("상품 수정 실패(상품 이름 중복) 테스트")
+    void modifyFailWhenNameAlreadyExistsTest() throws Exception {
+        // given
+        doThrow(new ProductException(ProductErrorCode.EXISTS_NAME)).when(productService)
+                .modify(eq(1L), any(ProductForm.class));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(patch("/api/v1/products/1")
+                .content("""
+                                {
+                                    "name": "Test Product Name",
+                                    "content": "Test Product content",
+                                    "price": 1000,
+                                    "imgUrl": "Test Product Image URL",
+                                    "quantity": 10
+                                }
+                                """)
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(ProductController.class))
+                .andExpect(handler().methodName("modify"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("중복된 상품 이름입니다."));
+    }
+
 }

--- a/backend/src/test/java/com/example/backend/domain/product/repository/ProductRepositoryTest.java
+++ b/backend/src/test/java/com/example/backend/domain/product/repository/ProductRepositoryTest.java
@@ -73,12 +73,10 @@ public class ProductRepositoryTest {
 
     @Test
     @DisplayName("상품 이름 유일성 검사(중복) 테스트")
-    void existsProductTest() {
+    void existsByNameTest() {
         //given
-        String name = "Test Product Name";
-
         //when
-        Boolean isExists = productRepository.existsByName(name);
+        Boolean isExists = productRepository.existsByName(name1);
 
         //then
         assertThat(isExists).isTrue();
@@ -86,7 +84,7 @@ public class ProductRepositoryTest {
 
     @Test
     @DisplayName("상품 이름 유일성 검사(유일) 테스트")
-    void notExistsProductTest() {
+    void notExistsByNameTest() {
         //given
         String name = "Unique Product Name";
 
@@ -95,6 +93,30 @@ public class ProductRepositoryTest {
 
         //then
         assertThat(isExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("상품 특정 id 제외 이름 유일성 검사 테스트")
+    void existsByNameAndIdNotTest() {
+        //given
+        String name2 = "Test Product Name2";
+        String uniqueName = "Unique Product Name";
+
+        Product product2 = Product.builder()
+                .name(name2)
+                .build();
+        productRepository.save(product2);
+        Long id = 2L;
+
+        //when
+        Boolean isExists1 = productRepository.existsByNameAndIdNot(name2, id);  // 수정 목표 상품 id의 name
+        Boolean isExists2 = productRepository.existsByNameAndIdNot(name1, id);  // 다른 상품의 name
+        Boolean isExists3 = productRepository.existsByNameAndIdNot(uniqueName, id); // 수정 했을 때 아예 다른 name
+
+        //then
+        assertThat(isExists1).isFalse();
+        assertThat(isExists2).isTrue();
+        assertThat(isExists3).isFalse();
     }
 
     @Test


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

### 상품 수정 시 해당 상품 id제외하고 상품 이름 중복 체크하는 로직 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- [x] 상품 수정 시에도 이름 중복 체크를 하지만 기존 이름은 그대로 사용할 수 있도록 구현
- [x] 관련  jpa테스트, 중복으로 인한 수정 실패 테스트 케이스 추가 

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
