### PR TITLE
Feature/M-05 회원 탈퇴 기능

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
@@ -14,4 +14,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     @Query("SELECT c FROM Cart c JOIN FETCH c.product WHERE c.member = :member")
     List<Cart> findAllByMemberWithProducts(@Param("member") Member member);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
@@ -61,4 +61,8 @@ public class CartService {
         return CartConverter.toResponseList(cartList);
     }
 
+
+    public void deleteByMemberId(Long memberId) {
+        cartRepository.deleteByMemberId(memberId);
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
@@ -61,7 +61,7 @@ public class CartService {
         return CartConverter.toResponseList(cartList);
     }
 
-
+    @Transactional
     public void deleteByMemberId(Long memberId) {
         cartRepository.deleteByMemberId(memberId);
     }

--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -58,5 +59,11 @@ public class MemberController {
 		@RequestBody @Validated(ValidationSequence.class) MemberModifyForm memberModifyForm) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(GenericResponse.of(memberService.modify(customUserDetails.getMember().toModel(), memberModifyForm)));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<GenericResponse<Void>> delete(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		memberService.delete(customUserDetails.getMember().toModel());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(GenericResponse.of());
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/example/backend/domain/member/controller/MemberController.java
@@ -16,13 +16,16 @@ import com.example.backend.domain.member.conveter.MemberConverter;
 import com.example.backend.domain.member.dto.MemberInfoResponse;
 import com.example.backend.domain.member.dto.MemberModifyForm;
 import com.example.backend.domain.member.dto.MemberSignupForm;
+import com.example.backend.domain.member.service.MemberDeleteService;
 import com.example.backend.domain.member.service.MemberService;
 import com.example.backend.global.auth.model.CustomUserDetails;
+import com.example.backend.global.auth.service.CookieService;
 import com.example.backend.global.response.GenericResponse;
 import com.example.backend.global.validation.ValidationSequence;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -31,6 +34,8 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "ApiV1MemberController", description = "API 회원 컨트롤러")
 public class MemberController {
 	private final MemberService memberService;
+	private final MemberDeleteService memberDeleteService;
+	private final CookieService cookieService;
 
 	@Operation(summary = "회원 가입")
 	@PostMapping("/join")
@@ -61,9 +66,13 @@ public class MemberController {
 			.body(GenericResponse.of(memberService.modify(customUserDetails.getMember().toModel(), memberModifyForm)));
 	}
 
+	@Operation(summary = "회원 탈퇴")
 	@DeleteMapping
-	public ResponseEntity<GenericResponse<Void>> delete(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-		memberService.delete(customUserDetails.getMember().toModel());
+	public ResponseEntity<GenericResponse<Void>> delete(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		HttpServletResponse response) {
+		cookieService.deleteAccessTokenFromCookie(response);
+		cookieService.deleteRefreshTokenFromCookie(response);
+		memberDeleteService.delete(customUserDetails.getMember().toModel());
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(GenericResponse.of());
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberDeleteService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberDeleteService.java
@@ -2,6 +2,7 @@ package com.example.backend.domain.member.service;
 
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.dto.MemberDto;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberDeleteService {
 
 	private final MemberRepository memberRepository;

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberDeleteService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberDeleteService.java
@@ -1,0 +1,31 @@
+package com.example.backend.domain.member.service;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import com.example.backend.domain.cart.service.CartService;
+import com.example.backend.domain.member.dto.MemberDto;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.member.repository.MemberRepository;
+import com.example.backend.domain.orders.service.OrdersService;
+import com.example.backend.global.redis.service.RedisService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDeleteService {
+
+	private final MemberRepository memberRepository;
+	private final RedisService redisService;
+	private final CartService cartService;
+	private final OrdersService ordersService;
+
+	public void delete(MemberDto memberDto) {
+		redisService.delete(memberDto.username());
+		SecurityContextHolder.clearContext();
+		cartService.deleteByMemberId(memberDto.id());
+		ordersService.deleteByMemberId(memberDto.id());
+		memberRepository.delete(Member.from(memberDto));
+	}
+}

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -118,5 +119,11 @@ public class MemberService {
 		if (nicknameExists) {
 			throw new MemberException(MemberErrorCode.EXISTS_NICKNAME);
 		}
+	}
+
+	public void delete(MemberDto memberDto) {
+		redisService.delete(memberDto.username());
+		SecurityContextHolder.clearContext();
+		memberRepository.delete(Member.from(memberDto));
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -119,11 +118,5 @@ public class MemberService {
 		if (nicknameExists) {
 			throw new MemberException(MemberErrorCode.EXISTS_NICKNAME);
 		}
-	}
-
-	public void delete(MemberDto memberDto) {
-		redisService.delete(memberDto.username());
-		SecurityContextHolder.clearContext();
-		memberRepository.delete(Member.from(memberDto));
 	}
 }

--- a/backend/src/main/java/com/example/backend/domain/orders/repository/OrdersRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/orders/repository/OrdersRepository.java
@@ -37,5 +37,5 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
             @Param("id") Long id,
             @Param("status") List<DeliveryStatus> status);
 
-
+    void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/example/backend/domain/orders/service/OrdersService.java
+++ b/backend/src/main/java/com/example/backend/domain/orders/service/OrdersService.java
@@ -48,6 +48,10 @@ public class OrdersService {
         return OrdersConverter.from(ordersList);
     }
 
+    public void deleteByMemberId(Long id) {
+        ordersRepository.deleteByMemberId(id);
+    }
+
 
     @Transactional
     public Long create(OrdersForm ordersForm, Member member) {

--- a/backend/src/main/java/com/example/backend/domain/orders/service/OrdersService.java
+++ b/backend/src/main/java/com/example/backend/domain/orders/service/OrdersService.java
@@ -48,11 +48,6 @@ public class OrdersService {
         return OrdersConverter.from(ordersList);
     }
 
-    public void deleteByMemberId(Long id) {
-        ordersRepository.deleteByMemberId(id);
-    }
-
-
     @Transactional
     public Long create(OrdersForm ordersForm, Member member) {
         List<ProductOrders> productOrdersList = createProductOrdersList(ordersForm);
@@ -90,5 +85,10 @@ public class OrdersService {
         ).orElseThrow(() -> new OrdersException(OrdersErrorCode.NOT_FOUND));
 
         return OrdersConverter.from(ordersList);
+    }
+
+    @Transactional
+    public void deleteByMemberId(Long id) {
+        ordersRepository.deleteByMemberId(id);
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/member/service/MemberDeleteServiceTest.java
+++ b/backend/src/test/java/com/example/backend/domain/member/service/MemberDeleteServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.backend.domain.member.service;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.backend.domain.cart.service.CartService;
+import com.example.backend.domain.member.dto.MemberDto;
+import com.example.backend.domain.member.entity.Member;
+import com.example.backend.domain.member.entity.Role;
+import com.example.backend.domain.member.repository.MemberRepository;
+import com.example.backend.domain.orders.service.OrdersService;
+import com.example.backend.global.redis.service.RedisService;
+
+@ExtendWith(MockitoExtension.class)
+class MemberDeleteServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private RedisService redisService;
+
+	@Mock
+	private CartService cartService;
+
+	@Mock
+	private OrdersService ordersService;
+
+	@InjectMocks
+	private MemberDeleteService memberDeleteService;
+
+	@Test
+	@DisplayName("회원 탈퇴 성공 테스트")
+	void delete_success() {
+		// given
+		MemberDto memberDto = MemberDto.builder()
+			.id(1L)
+			.username("user@gmail.com")
+			.nickname("user")
+			.role(Role.ROLE_USER)
+			.build();
+
+		// when
+		memberDeleteService.delete(memberDto);
+
+		// then
+		verify(redisService).delete("user@gmail.com");
+		verify(cartService).deleteByMemberId(1L);
+		verify(ordersService).deleteByMemberId(1L);
+		verify(memberRepository).delete(any(Member.class));
+	}
+}


### PR DESCRIPTION
## 📌 회원 탈퇴 기능

## 👩‍💻 요구 사항과 구현 내용

### 요구사항
- 로그인 한 사용자는 회원 탈퇴를 할 수 있다.
- 회원 탈퇴 시 주문 정보와, 카트 정보는 모두 삭제된다.

### 구현 내용
- 멤버 서비스에 의존성이 너무 많이 추가되는 것 같아서 MemberDeleteService로 분리
- 쿠키, 시큐리티 컨텍스트, 주문, 카트 모두 삭제

close #73 