### PR TITLE
Feature/C-03 장바구니 상품 수량 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
@@ -7,11 +7,12 @@ import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.entity.Member;
 import com.example.backend.global.auth.model.CustomUserDetails;
 import com.example.backend.global.response.GenericResponse;
-import jakarta.validation.Valid;
+import com.example.backend.global.validation.ValidationSequence;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,7 +25,7 @@ public class CartController {
 
     @PostMapping
     public ResponseEntity<GenericResponse<Long>> addCartItem(
-            @RequestBody @Valid CartForm cartForm,
+            @RequestBody @Validated(ValidationSequence.class) CartForm cartForm,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         Member member = customUserDetails.getMember();
@@ -47,7 +48,7 @@ public class CartController {
 
     @PatchMapping
     public ResponseEntity<GenericResponse<Long>> updateCartItemQuantity(
-            @RequestBody @Valid CartUpdateForm cartUpdateForm,
+            @RequestBody @Validated(ValidationSequence.class) CartUpdateForm cartUpdateForm,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         Member member = customUserDetails.getMember();

--- a/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/controller/CartController.java
@@ -2,6 +2,7 @@ package com.example.backend.domain.cart.controller;
 
 import com.example.backend.domain.cart.dto.CartForm;
 import com.example.backend.domain.cart.dto.CartResponse;
+import com.example.backend.domain.cart.dto.CartUpdateForm;
 import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.entity.Member;
 import com.example.backend.global.auth.model.CustomUserDetails;
@@ -43,4 +44,16 @@ public class CartController {
 
         return ResponseEntity.status(HttpStatus.OK).body(GenericResponse.of(cartResponses));
     }
+
+    @PatchMapping
+    public ResponseEntity<GenericResponse<Long>> updateCartItemQuantity(
+            @RequestBody @Valid CartUpdateForm cartUpdateForm,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
+        Long cartId = cartService.updateCartItemQuantity(cartUpdateForm, member);
+
+        return ResponseEntity.status(HttpStatus.OK).body(GenericResponse.of(cartId));
+    }
+
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/dto/CartForm.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/dto/CartForm.java
@@ -1,14 +1,15 @@
 package com.example.backend.domain.cart.dto;
 
+import com.example.backend.global.validation.ValidationSequence;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record CartForm(
-        @NotNull(message = "회원 ID는 필수 값입니다.")
+        @NotNull(message = "회원 ID는 필수 값입니다.", groups = ValidationSequence.class)
         Long memberId,
-        @NotNull(message = "상품 ID는 필수 값입니다.")
+        @NotNull(message = "상품 ID는 필수 값입니다.", groups = ValidationSequence.class)
         Long productId,
-        @Min(value = 1, message = "상품 수량은 최소 1개 이상이어야 합니다.")
+        @Min(value = 1, message = "상품 수량은 최소 1개 이상이어야 합니다.", groups = ValidationSequence.class)
         int quantity
 ) {
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/dto/CartUpdateForm.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/dto/CartUpdateForm.java
@@ -1,0 +1,11 @@
+package com.example.backend.domain.cart.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record CartUpdateForm(
+        @NotNull(message = "상품 ID는 필수 값입니다.")
+        Long productId,
+        @Min(value = 1, message = "상품 수량은 최소 1개 이상이어야 합니다.")
+        int quantity
+) {}

--- a/backend/src/main/java/com/example/backend/domain/cart/dto/CartUpdateForm.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/dto/CartUpdateForm.java
@@ -1,11 +1,12 @@
 package com.example.backend.domain.cart.dto;
 
+import com.example.backend.global.validation.ValidationSequence;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record CartUpdateForm(
-        @NotNull(message = "상품 ID는 필수 값입니다.")
+        @NotNull(message = "상품 ID는 필수 값입니다.", groups = ValidationSequence.class)
         Long productId,
-        @Min(value = 1, message = "상품 수량은 최소 1개 이상이어야 합니다.")
+        @Min(value = 1, message = "상품 수량은 최소 1개 이상이어야 합니다.", groups = ValidationSequence.class)
         int quantity
 ) {}

--- a/backend/src/main/java/com/example/backend/domain/cart/entity/Cart.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/entity/Cart.java
@@ -31,4 +31,8 @@ public class Cart {
         this.product = product;
         this.quantity = quantity;
     }
+
+    public void updateQuantity(int quantity) {
+        this.quantity = quantity;
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/exception/CartErrorCode.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/exception/CartErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CartErrorCode {
     ALREADY_EXISTS_IN_CART(HttpStatus.BAD_REQUEST, "이미 장바구니에 추가된 상품입니다.", "400-1"),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST,"상품을 최소 1개 이상 추가하여야 합니다." ,"400-2"),
-    INVALID_MEMBER(HttpStatus.FORBIDDEN,"요청한 회원 ID와 로그인한 회원 ID가 다릅니다." ,"403-1");
+    SAME_QUANTITY_IN_CART(HttpStatus.BAD_REQUEST, "현재 수량과 동일한 수량입니다.", "400-3"),
+    PRODUCT_NOT_FOUND_IN_CART(HttpStatus.NOT_FOUND, "장바구니에 존재하지 않는 상품입니다.", "404-1");
 
     final HttpStatus httpStatus;
     final String message;

--- a/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
@@ -16,4 +17,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     List<Cart> findAllByMemberWithProducts(@Param("member") Member member);
 
     void deleteByMemberId(Long memberId);
+
+    Optional<Cart> findByProductIdAndMemberId(Long productId, Long memberId);
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/repository/CartRepository.java
@@ -18,5 +18,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     void deleteByMemberId(Long memberId);
 
-    Optional<Cart> findByProductIdAndMemberId(Long productId, Long memberId);
+    @Query("SELECT c FROM Cart c JOIN FETCH c.member WHERE c.product.id = :productId AND c.member.id = :memberId")
+    Optional<Cart> findByProductIdAndMemberId(@Param("productId") Long productId, @Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
+++ b/backend/src/main/java/com/example/backend/domain/cart/service/CartService.java
@@ -75,9 +75,6 @@ public class CartService {
         // 수량 업데이트
         cart.updateQuantity(cartUpdateForm.quantity());
 
-        // 장바구니 수량 업데이트 후 저장
-        cartRepository.save(cart);
-
         return cart.getId();
     }
 }

--- a/backend/src/test/java/com/example/backend/domain/cart/controller/CartControllerTest.java
+++ b/backend/src/test/java/com/example/backend/domain/cart/controller/CartControllerTest.java
@@ -2,6 +2,7 @@ package com.example.backend.domain.cart.controller;
 
 import com.example.backend.domain.cart.dto.CartForm;
 import com.example.backend.domain.cart.dto.CartResponse;
+import com.example.backend.domain.cart.dto.CartUpdateForm;
 import com.example.backend.domain.cart.exception.CartException;
 import com.example.backend.domain.cart.service.CartService;
 import com.example.backend.domain.member.entity.Member;
@@ -121,5 +122,32 @@ class CartControllerTest {
         assertTrue(response.getBody().getData().isEmpty());
 
         verify(cartService).getCartByMember(member);
+    }
+
+    /**
+     * updateCartItemQuantity() 메서드 테스트
+     * - 장바구니 상품 수량 변경
+     * @throws CartException
+     */
+    @Test
+    @WithMockUser
+    @DisplayName("장바구니 상품 수량 변경")
+    void updateCartItemQuantity() throws CartException {
+        // given
+        Long cartId = 1L;
+        CartUpdateForm cartUpdateForm = new CartUpdateForm(1L, 3);
+
+        when(cartService.updateCartItemQuantity(cartUpdateForm, member)).thenReturn(cartId);
+
+        // when
+        ResponseEntity<GenericResponse<Long>> response = cartController
+                .updateCartItemQuantity(cartUpdateForm, customUserDetails);
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(cartId, response.getBody().getData());
+
+        verify(cartService).updateCartItemQuantity(cartUpdateForm, member);
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 
- 로그인한 회원이 장바구니에 있는 상품의 수량을 수정합니다.

## 👩‍💻 요구 사항과 구현 내용
- [x] 회원은 로그인을 하고 본인의 장바구니에서 추가되었던 상품의 수량을 수정할 수 있습니다.
- [x] 수량은 최소 1이상으로 변경하여야 합니다.
- [x] 만약 현재 수량과 동일한 수량으로 수정한다면 예외를 발생시킵니다.
----
- 수량 수정을 위한 DTO(CartUpdateForm)를 추가
- jakarta.validation으로 값 검증
- 수량 체크와 존재하지 않는 상품에 대한 ErrorCode 추가
- Cart 엔티티에 수량 업데이트하는 updateQuantity 메서드 추가
- updateCartItemQuantity로 수량 업데이트하는 로직 구현
- 그에 따른 테스트 코드 작성

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점

Close #70
