### PR TITLE
A-07 / 만료된 액세스 토큰으로 로그아웃 요청시 에러 발생 문제 해결

### DIFF
--- a/backend/src/main/java/com/example/backend/global/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/example/backend/global/auth/controller/AuthController.java
@@ -49,9 +49,9 @@ public class AuthController {
 	@Operation(summary = "로그아웃", description = "accessToken, refreshToken 을 제거")
     @PostMapping("/logout")
     public ResponseEntity<GenericResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
-        String accessToken = cookieService.getAccessTokenFromRequest(request);
+        String refreshToken = cookieService.getRefreshTokenFromRequest(request);
 
-        authService.logout(accessToken);
+        authService.logout(refreshToken);
 		cookieService.deleteAccessTokenFromCookie(response);
         cookieService.deleteRefreshTokenFromCookie(response);
 


### PR DESCRIPTION
## 📌 과제 설명
만료된 액세스 토큰으로 로그아웃 요청시 에러 발생 문제 해결

## 👩‍💻 요구 사항과 구현 내용
- 만료된 토큰으로 로그아웃 진행시, 액세스 토큰을 갱신하고 response 쿠키에만 담기 때문에, 기존 요청은 그대로 액세스 토큰이 없는 상태로 넘어감
- 이 때 액세스 토큰을 파싱하려고 하면 에러 발생
- 리프레시 토큰으로 파싱해서 유저정보를 얻고 로그아웃 로직 진행

close #101 
