### PR TITLE
Feature/M-03 회원 수정시 닉네임 변경이 있을 때만 닉네임 검증

### DIFF
--- a/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/backend/domain/member/service/MemberService.java
@@ -90,7 +90,9 @@ public class MemberService {
 	}
 
 	public MemberInfoResponse modify(MemberDto memberDto, MemberModifyForm memberModifyForm) {
-		existsNickname(memberModifyForm.nickname());
+		if (!memberDto.nickname().equals(memberModifyForm.nickname())) {
+			existsNickname(memberModifyForm.nickname());
+		}
 
 		return MemberConverter.from(
 			memberRepository.save(MemberConverter.of(memberDto, memberModifyForm)));

--- a/backend/src/test/java/com/example/backend/global/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/backend/global/auth/controller/AuthControllerTest.java
@@ -418,14 +418,14 @@ public class AuthControllerTest {
 	@WithMockUser
 	void logout_success() throws Exception {
 		// given
-		String accessToken = "accessToken";
-		when(cookieService.getAccessTokenFromRequest(any(HttpServletRequest.class))).thenReturn(accessToken);
-		doNothing().when(authService).logout(accessToken);
+		String refreshToken = "refreshToken";
+		when(cookieService.getRefreshTokenFromRequest(any(HttpServletRequest.class))).thenReturn(refreshToken);
+		doNothing().when(authService).logout(refreshToken);
 		doNothing().when(cookieService).deleteRefreshTokenFromCookie(any(HttpServletResponse.class));
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/logout")
-			.cookie(new Cookie("accessToken", accessToken)));
+			.cookie(new Cookie("refreshToken", refreshToken)));
 
 		// then
 		resultActions
@@ -434,8 +434,8 @@ public class AuthControllerTest {
 			.andExpect(jsonPath("$.message").value("로그아웃 성공"))
 			.andExpect(jsonPath("$.data").isEmpty());
 
-		verify(cookieService, times(1)).getAccessTokenFromRequest(any(HttpServletRequest.class));
-		verify(authService, times(1)).logout(accessToken);
+		verify(cookieService, times(1)).getRefreshTokenFromRequest(any(HttpServletRequest.class));
+		verify(authService, times(1)).logout(refreshToken);
 		verify(cookieService, times(1)).deleteRefreshTokenFromCookie(any(HttpServletResponse.class));
 	}
 


### PR DESCRIPTION
## 📌 과제 설명 
회원 수정 로직 변경

## 👩‍💻 요구 사항과 구현 내용
- 회원 닉네임과 수정 폼 닉네임을 비교해서 변경이 있을 때만 닉네임 검증을 하도록 수정
- 로그아웃 테스트 수정

close #103 